### PR TITLE
fix workflow

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -25,29 +25,7 @@ jobs:
         name: airrohr-flasher
         path: dist/airrohr-flasher
         
-  buildUbuntu18:
-
-    runs-on: ubuntu-18.04
-
-    steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python 3.6
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.6
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install qttools5-dev-tools pyqt5-dev-tools qt5-default python3-pip python3.6 make
-    - name: build with pyinstaller
-      run: |
-        make deps dist && ls dist/
-    - uses: actions/upload-artifact@v2
-      with:
-        name: airrohr-flasher-ubuntu18
-        path: dist/airrohr-flasher
-        
-  buildUbuntuLatest:
+  buildUbuntu20:
 
     runs-on: ubuntu-20.04
 

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -49,7 +49,7 @@ jobs:
         
   buildUbuntuLatest:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
- change `ubuntu-latest` to `ubuntu-20.04` in order to build assets, as Ubuntu-22.04 does not support Python3.6
- remove the build on Ubuntu 18.04 since it is deprecated in Github Actions